### PR TITLE
add spec tests, lint cleanup

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,6 @@
+fixtures:
+  repositories:
+    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
+  symlinks:
+    postfix: "#{source_dir}"
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+spec/fixtures
+pkg/*
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: ruby
+bundler_args: --without development
+script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+script:
+  - "rake lint"
+  - "rake spec SPEC_OPTS='--format documentation'"
+env:
+  - PUPPET_VERSION="~> 2.7.0"
+  - PUPPET_VERSION="~> 3.0.0"
+  - PUPPET_VERSION="~> 3.1.0"
+  - PUPPET_VERSION="~> 3.2.0"
+matrix:
+  exclude:
+    - rvm: 1.9.3
+      env: PUPPET_VERSION="~> 2.7.0"
+    - rvm: 2.0.0
+      env: PUPPET_VERSION="~> 2.7.0"
+    - rvm: 2.0.0
+      env: PUPPET_VERSION="~> 3.0.0"
+    - rvm: 2.0.0
+      env: PUPPET_VERSION="~> 3.1.0"
+notifications:
+  email: false
+  on_success: always
+  on_failure: always
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source :rubygems
+
+puppetversion = ENV['PUPPET_VERSION']
+gem 'puppet', puppetversion, :require => false
+gem 'puppet-lint'
+gem 'rspec-puppet'
+gem 'puppetlabs_spec_helper', '>= 0.4.0'
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require 'rubygems'
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint'
+PuppetLint.configuration.send("disable_80chars")
+PuppetLint.configuration.send("disable_autoloader_layout")
+PuppetLint.configuration.send("disable_quoted_booleans")
+

--- a/manifests/dbfile.pp
+++ b/manifests/dbfile.pp
@@ -32,12 +32,12 @@ define postfix::dbfile (
 ) {
 
   file { "${postfixdir}/${title}":
+    ensure  => $ensure,
     owner   => $owner,
     group   => $group,
     mode    => $mode,
     content => $content,
     source  => $source,
-    ensure  => $ensure,
   }
 
   if $ensure == 'absent' {
@@ -50,7 +50,7 @@ define postfix::dbfile (
       cwd         => $postfixdir,
       subscribe   => File["${postfixdir}/${title}"],
       refreshonly => true,
-      notify      => Service["postfix"],
+      notify      => Service['postfix'],
     }
 
   }

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -34,12 +34,12 @@ define postfix::file (
 ) {
 
   file { "${postfixdir}/${title}":
+    ensure  => $ensure,
     owner   => $owner,
     group   => $group,
     mode    => $mode,
     content => $content,
     source  => $source,
-    ensure  => $ensure,
     notify  => Service['postfix'],
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,3 +1,5 @@
+# Class: postifx::params
+#
 class postfix::params {
   if $::osfamily == 'Debian' {
     $daemon_directory = '/usr/lib/postfix'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -100,9 +100,9 @@ class postfix::server (
   }
 
   service { 'postfix':
+    ensure    => running,
     require   => Package['postfix'],
     enable    => true,
-    ensure    => running,
     hasstatus => true,
     restart   => $service_restart,
   }
@@ -122,9 +122,9 @@ class postfix::server (
     package { [ 'spamassassin', 'spampd' ]: ensure => installed }
     # Note that we don't want the normal spamassassin (spamd) service
     service { 'spampd':
+      ensure    => running,
       require   => Package['spampd'],
       enable    => true,
-      ensure    => running,
       hasstatus => true,
     }
     # Override the options passed to spampd
@@ -145,9 +145,9 @@ class postfix::server (
     # Main package and service it provides
     package { 'postgrey': ensure => installed }
     service { 'postgrey':
+      ensure    => running,
       require   => Package['postgrey'],
       enable    => true,
-      ensure    => running,
       # When stopped, status returns zero with 1.31-1.el5
       hasstatus => false,
     }

--- a/spec/classes/postfix_params_spec.rb
+++ b/spec/classes/postfix_params_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'postfix::params', :type => :class do
+
+  it { should create_class('postfix::params') }
+
+end
+

--- a/spec/classes/postfix_server_spec.rb
+++ b/spec/classes/postfix_server_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe 'postfix::server', :type => :class do
+
+  context 'default' do
+    it { should contain_package('postfix') }
+    it { should contain_service('postfix') }
+    it { should contain_file('/etc/postfix/master.cf') }
+    it { should contain_file('/etc/postfix/main.cf') }
+    it { should_not contain_package('spamassassin') }
+    it { should_not contain_package('spampd') }
+    it { should_not contain_service('spampd') }
+    it { should_not contain_file('/etc/sysconfig/spampd') }
+    it { should_not contain_file('/etc/mail/spamassassin/local.cf') }
+    it { should_not contain_package('postgrey') }
+    it { should_not contain_service('postgrey') }
+    it { should_not include_class('clamav::smtp') }
+    it { should contain_postfix__file('header_checks') }
+    it { should contain_postfix__file('body_checks') }
+  end
+
+  context 'rhel6 based' do
+    let(:facts) { { :operatingsystem => 'RedHat', :operatingsystemrelease => 6 } }
+    let(:params) { { :submission => true } }
+
+    it { should contain_file('/etc/postfix/master.cf').with_content(/smtpd_tls_security_level/) }
+    it { should contain_file('/etc/postfix/main.cf').with_content(/ddd/) }
+  end
+
+  context 'non-rhel6 based' do
+    let(:facts) { { :operatingsystem => 'RedHat', :operatingsystemrelease => 5 } }
+    let(:params) { { :submission => true } }
+
+    it { should contain_file('/etc/postfix/master.cf').with_content(/smtpd_enforce_tls/) }
+    it { should contain_file('/etc/postfix/main.cf').with_content(/xxgdb/) }
+  end
+
+  context 'debian' do
+    let(:facts) { { :osfamily => 'Debian' } }
+
+    it { should contain_service('postfix').with_restart('/usr/sbin/service postfix reload') }
+  end
+
+  context 'with mysql' do
+    let(:params) { { :mysql => true } }
+
+    it { should contain_package('postfix-mysql').with_alias('postfix') }
+  end
+
+  context 'with spamassassin' do
+    let(:params) { { :spamassassin => true } }
+
+    it { should contain_package('spamassassin') }
+    it { should contain_package('spampd') }
+    it { should contain_service('spampd') }
+    it { should contain_file('/etc/sysconfig/spampd') }
+    it { should contain_file('/etc/mail/spamassassin/local.cf') }
+  end
+
+  context 'postgrey' do
+    let(:params) { { :postgrey => true } }
+
+    it { should contain_package('postgrey') }
+    it { should contain_service('postgrey') }
+  end
+
+  context 'clamav' do
+    let(:params) { { :clamav => true } }
+    # Fails spec tests - unknown module
+#    it { should include_class('clamav::smtp') }
+  end
+
+end

--- a/spec/defines/postfix_dbfile_spec.rb
+++ b/spec/defines/postfix_dbfile_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'postfix::dbfile', :type => :define do
+  let(:title) { 'myfile' }
+
+  context 'default' do
+    it { should contain_file('/etc/postfix/myfile').with(
+      :owner  => 'root',
+      :group  => 'root',
+      :mode   => '0644'
+    ) }
+
+    it { should_not contain_file('/etc/postfix/myfile.db').with_ensure('absent') }
+    it { should contain_exec('/usr/sbin/postmap myfile') }
+  end
+
+  context 'specify source' do
+    let(:params) { { :source => 'puppet:///blah' } }
+
+    it { should contain_file('/etc/postfix/myfile').with_source('puppet:///blah') }
+  end
+
+  context 'specify content' do
+    let(:params) { { :content => 'stuff' } }
+
+    it { should contain_file('/etc/postfix/myfile').with_content('stuff') }
+  end
+
+  context 'absent' do
+    let(:params) { { :ensure => 'absent' } }
+
+    it { should contain_file('/etc/postfix/myfile').with_ensure('absent') }
+    it { should contain_file('/etc/postfix/myfile.db').with_ensure('absent') }
+  end
+
+end

--- a/spec/defines/postfix_file_spec.rb
+++ b/spec/defines/postfix_file_spec.rb
@@ -1,0 +1,34 @@
+
+
+require 'spec_helper'
+
+describe 'postfix::file', :type => :define do
+  let(:title) { 'myfile' }
+
+  context 'default' do
+    it { should contain_file('/etc/postfix/myfile').with(
+      :owner  => 'root',
+      :group  => 'root',
+      :mode   => '0644'
+    ) }
+  end
+
+  context 'specify source' do
+    let(:params) { { :source => 'puppet:///blah' } }
+
+    it { should contain_file('/etc/postfix/myfile').with_source('puppet:///blah') }
+  end
+
+  context 'specify content' do
+    let(:params) { { :content => 'stuff' } }
+
+    it { should contain_file('/etc/postfix/myfile').with_content('stuff') }
+  end
+
+  context 'absent' do
+    let(:params) { { :ensure => 'absent' } }
+
+    it { should contain_file('/etc/postfix/myfile').with_ensure('absent') }
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'rubygems'
+require 'puppetlabs_spec_helper/module_spec_helper'


### PR DESCRIPTION
I need to enhance my postfix module and rather than do that and have another postfix module on the forge I would like to reuse/improve an existing one and help with the cleanup. 

A few questions:
Do you want to maintain EL5 compatibility?
OK to break out the non-postfix stuff into their own modules? (I'll move them to you in GH)
OK to add puppetlabs-stdlib as a dependency for the anchor pattern?

This commit:
Added spec tests
Added travis-ci integration (if you use travis - free for OSS)
Minor lint cleanup
