### PR TITLE
add setgid_group option in main.cf

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -33,6 +33,7 @@ class postfix::server (
   $mail_spool_directory = false,
   $mailbox_command = false,
   $smtpd_banner = '$myhostname ESMTP $mail_name',
+  $setgid_group = 'postdrop',
   $message_size_limit = false,
   $mail_name = false,
   $virtual_alias_domains = false,

--- a/templates/main.cf-el6.erb
+++ b/templates/main.cf-el6.erb
@@ -696,7 +696,7 @@ mailq_path = /usr/bin/mailq.postfix
 # commands.  This must be a group name with a numerical group ID that
 # is not shared with other accounts, not even with the Postfix account.
 #
-setgid_group = postdrop
+setgid_group = <%= setgid_group %>
 
 # html_directory: The location of the Postfix HTML documentation.
 #

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -687,7 +687,7 @@ mailq_path = /usr/bin/mailq.postfix
 # commands.  This must be a group name with a numerical group ID that
 # is not shared with other accounts, not even with the Postfix account.
 #
-setgid_group = postdrop
+setgid_group = <%= setgid_group %>
 
 # html_directory: The location of the Postfix HTML documentation.
 #


### PR DESCRIPTION
I hate a problem witch SLES11SP1, the option 'setgid_group' is 'maildrop'.
I added this option to server.pp and the main.cf templates.
