### PR TITLE
Add parameters for ssl_cert and ssl_key.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -47,6 +47,8 @@ class postfix::server (
   $smtpd_sender_restrictions = [],
   $smtpd_recipient_restrictions = [],
   $ssl = false,
+  $ssl_cert = false,
+  $ssl_key = false,
   $smtpd_sasl_auth = false,
   $smtpd_sasl_type = 'dovecot',
   $smtpd_sasl_path = 'private/auth',

--- a/templates/main.cf-el5.erb
+++ b/templates/main.cf-el5.erb
@@ -710,8 +710,8 @@ readme_directory = /usr/share/doc/postfix-2.3.3/README_FILES
 # TLS stuff
 smtpd_use_tls = yes
 smtpd_tls_loglevel = 1
-smtpd_tls_key_file = /etc/pki/tls/private/<%= @ssl %>.key
-smtpd_tls_cert_file = /etc/pki/tls/certs/<%= @ssl %>.crt
+smtpd_tls_key_file = <%= @ssl_key %>
+smtpd_tls_cert_file = <%= @ssl_cert %>
 
 <% end -%>
 <% if @smtpd_sasl_auth -%>

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -719,8 +719,8 @@ readme_directory = /usr/share/doc/postfix-2.6.6/README_FILES
 # TLS stuff
 smtpd_use_tls = yes
 smtpd_tls_loglevel = 1
-smtpd_tls_key_file = /etc/pki/tls/private/<%= @ssl %>.key
-smtpd_tls_cert_file = /etc/pki/tls/certs/<%= @ssl %>.crt
+smtpd_tls_key_file = <%= @ssl_key %>
+smtpd_tls_cert_file = <%= @ssl_cert %>
 
 <% end -%>
 <% if @smtpd_sasl_auth -%>


### PR DESCRIPTION
Allow the user to specify arbitrary ssl certificates and keys. There is no reason to lock the user to a specific file structure in this case.
