### PR TITLE
Correct daemon_directory for Debian

### DIFF
--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -39,7 +39,7 @@ command_directory = /usr/sbin
 # daemon programs (i.e. programs listed in the master.cf file). This
 # directory must be owned by root.
 #
-daemon_directory = /usr/libexec/postfix
+daemon_directory = <%= @daemon_directory %>
 
 # The data_directory parameter specifies the location of Postfix-writable
 # data files (caches, random numbers). This directory must be owned


### PR DESCRIPTION
dameon_directory should use <%= @daemon_directory %> variable (from postfix::params)
