### PR TITLE
Don't emit "check_policy_service" line when postgrey is disabled

### DIFF
--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -895,10 +895,12 @@ smtpd_recipient_restrictions =
 <% @smtpd_recipient_restrictions.each do |line| -%>
   <%= line %>,
 <% end -%>
+<% if @postgrey -%>
 <% if @postgrey_policy_service -%>
   check_policy_service <%= @postgrey_policy_service %>,
 <% else -%>
   check_policy_service unix:postgrey/socket,
+<% end -%>
 <% end -%>
 
 <% end -%>


### PR DESCRIPTION
If `smtpd_recipient_restrictions` is not empty but `postgrey` is false (default), the `check_policy_service` line is emitted when it shouldn't be.
