### PR TITLE
Version numbers

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -156,7 +156,7 @@ class postfix::server (
 ) inherits ::postfix::params {
 
   # Default has el5 files, for el6 a few defaults have changed
-  if ( $::operatingsystem =~ /RedHat|CentOS/ and $::operatingsystemrelease < 6 ) {
+  if ( $::operatingsystem =~ /RedHat|CentOS/ and $::operatingsystemmajrelease < 6 ) {
     $filesuffix = '-el5'
   } else {
     $filesuffix = ''


### PR DESCRIPTION
Switch from using $operatingsystemrelease to $operatingsystemmajrelease because CentOS 7 changes the numbering. This change is safe with CentOS 6, but I don't have a CentOS 5 system to test with.
