### PR TITLE
RH/CentOS release version comparison fix

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -156,7 +156,7 @@ class postfix::server (
 ) inherits ::postfix::params {
 
   # Default has el5 files, for el6 a few defaults have changed
-  if ( $::operatingsystem =~ /RedHat|CentOS/ and $::operatingsystemrelease < 6 ) {
+  if ( $::operatingsystem =~ /RedHat|CentOS/ and versioncmp($::operatingsystemrelease, '6') < 0 ) {
     $filesuffix = '-el5'
   } else {
     $filesuffix = ''


### PR DESCRIPTION
New CentOS 7 contains version information consisted of three components

```
# facter | grep -i 7.0.1406
lsbdistdescription => CentOS Linux release 7.0.1406 (Core) 
lsbdistrelease => 7.0.1406
operatingsystemrelease => 7.0.1406
```

and current simple check `$::operatingsystemrelease < 6` fails on Puppet error `"Error: comparison of String with 6 failed at"`. Function **versioncmp** is better for version comparisons.
