### PR TITLE
fix error with puppet 3.6 comparing string to number

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -147,7 +147,7 @@ class postfix::server (
 ) inherits postfix::params {
 
   # Default has el5 files, for el6 a few defaults have changed
-  if ( $::operatingsystem =~ /RedHat|CentOS/ and $::operatingsystemrelease < 6 ) {
+  if ( $::operatingsystem =~ /RedHat|CentOS/ and $::operatingsystemmajrelease < 6 ) {
     $filesuffix = '-el5'
   } else {
     $filesuffix = ''


### PR DESCRIPTION
This fixes the error

Error: comparison of String with 6 failed at /etc/puppet/modules/postfix/manifests/server.pp:150

on puppet 3.6