### PR TITLE
Add allow_mail_to_files parameter

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -38,6 +38,7 @@ class postfix::server (
   $setgid_group = $::postfix::params::setgid_group,
   $mailbox_size_limit = undef,
   $message_size_limit = false,
+  $allow_mail_to_files = 'alias',
   $mail_name = false,
   $virtual_alias_domains = false,
   $virtual_alias_maps = false,

--- a/templates/main.cf-el5.erb
+++ b/templates/main.cf-el5.erb
@@ -803,7 +803,7 @@ message_size_limit = <%= @message_size_limit %>
 
 <% end -%>
 # Make nobody redirect to /dev/null work
-allow_mail_to_files = alias
+allow_mail_to_files = <%= @allow_mail_to_files %>
 
 <% if @virtual_alias_domains -%>
 virtual_alias_domains =

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -825,7 +825,7 @@ message_size_limit = <%= @message_size_limit %>
 
 <% end -%>
 # Make nobody redirect to /dev/null work
-allow_mail_to_files = alias
+allow_mail_to_files = <%= @allow_mail_to_files %>
 
 <% if @virtual_alias_domains -%>
 virtual_alias_domains =


### PR DESCRIPTION
The default in EL5 and EL6 for allow_mail_to_files is "alias, forward" so this parameter allows the default to be re-established while remaining backwards compatible.
