### PR TITLE
Fix spampd options

### DIFF
--- a/templates/sysconfig-spampd.erb
+++ b/templates/sysconfig-spampd.erb
@@ -1,2 +1,2 @@
 # Options for spampd, since the default ports conflict with other filters...
-options="--port=<%= @spampd_port %> --relayport=<%= @spampd_relayport %> --user=spampd --group=spampd --children=<%= @spampd_children %> --maxsize=<%= @spampd_maxsize %> --tagall --log-rules-hit --local-only"
+OPTIONS="--port=<%= @spampd_port %> --relayport=<%= @spampd_relayport %> --user=spampd --group=spampd --children=<%= @spampd_children %> --maxsize=<%= @spampd_maxsize %> --tagall --log-rules-hit --local-only"


### PR DESCRIPTION
spampd init references $OPTIONS - options in /etc/sysconfig/spampd are ignored.