### PR TITLE
Add a correct default for smtps_content_filter. Fixes #32.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -85,7 +85,7 @@ class postfix::server (
   $extra_main_parameters = {},
   # master.cf
   $smtp_content_filter = [],
-  $smtps_content_filter = $smtp_content_filter,
+  $smtps_content_filter = [],
   $submission = false,
   # EL5
   $submission_smtpd_enforce_tls = 'yes',


### PR DESCRIPTION
Using a class parameter to set the default value of another class
parameter does not work, here smtps_content_filter is null and not [] as
expected.

Fix #32.