### PR TITLE
add support for smtp_generic_maps

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -80,7 +80,9 @@ class postfix::server (
   $smtp_sasl_tls = false,
   $smtp_use_tls = false,
   $canonical_maps = false,
+  $canonical_maps = false,
   $sender_canonical_maps = false,
+  $smtp_generic_maps = false,
   $relocated_maps = false,
   $extra_main_parameters = {},
   # master.cf

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -80,7 +80,6 @@ class postfix::server (
   $smtp_sasl_tls = false,
   $smtp_use_tls = false,
   $canonical_maps = false,
-  $canonical_maps = false,
   $sender_canonical_maps = false,
   $smtp_generic_maps = false,
   $relocated_maps = false,

--- a/templates/main.cf-el5.erb
+++ b/templates/main.cf-el5.erb
@@ -917,6 +917,10 @@ canonical_maps = <%= @canonical_maps %>
 sender_canonical_maps = <%= @sender_canonical_maps %>
 
 <% end -%>
+<% if @smtp_generic_maps -%>
+smtp_generic_maps = <%= @smtp_generic_maps %>
+
+<% end -%>
 <% if ! @extra_main_parameters.empty? -%>
 # Parameters set using 'extra_main_parameters'
 <% @extra_main_parameters.sort_by {|key,value| key}.each do |key,value| -%>

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -926,6 +926,10 @@ canonical_maps = <%= @canonical_maps %>
 sender_canonical_maps = <%= @sender_canonical_maps %>
 
 <% end -%>
+<% if @smtp_generic_maps -%>
+smtp_generic_maps = <%= @smtp_generic_maps %>
+
+<% end -%>
 <% if @postscreen -%>
 # Postscreen configuration
 postscreen_access_list =


### PR DESCRIPTION
Optional lookup tables that perform address rewriting in the Postfix SMTP client, typically to transform a locally valid address into a globally valid address when sending mail across the Internet. This is needed when the local machine does not have its own Internet domain name, but uses something like localdomain.local instead. 