### PR TITLE
Add param and template for Regex check_recipient_access

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -104,6 +104,7 @@ class postfix::server (
   # Other files
   $header_checks = [],
   $body_checks = [],
+  $check_recipient_access = [],
   # Postscreen - available in Postfix 2.8 and later
   $postscreen                  = false,
   $postscreen_access_list      = ['permit_mynetworks'],
@@ -243,6 +244,13 @@ class postfix::server (
   # Regex body_checks
   postfix::file { 'body_checks':
     content    => template('postfix/body_checks.erb'),
+    group      => $root_group,
+    postfixdir => $config_directory,
+  }
+
+  # Regex check_recipient_access
+  postfix::file { 'check_recipient_access':
+    content    => template('postfix/check_recipient_access.erb'),
     group      => $root_group,
     postfixdir => $config_directory,
   }

--- a/templates/check_recipient_access.erb
+++ b/templates/check_recipient_access.erb
@@ -1,0 +1,3 @@
+<% @check_recipient_access.each do |line| -%>
+<%= line %>
+<% end -%>


### PR DESCRIPTION
Hello,

I'd like to configure and manage the check_recipient_access feature of postfix via your puppet-postfix module.

This pull request (attempts to...) add these as server params and associated template erb, as modeled by the header_checks and body_checks features already provided...

Thanks,
Wayde.