### PR TITLE
$smtps_content_filter shouldn't be obligatory when using $ssl

### DIFF
--- a/templates/master.cf.erb
+++ b/templates/master.cf.erb
@@ -32,8 +32,10 @@ smtps     inet  n       -       n       -       -       smtpd
   -o smtpd_sasl_auth_enable=<%= @smtps_smtpd_sasl_auth_enable %>
   -o smtpd_client_restrictions=<%= @smtps_smtpd_client_restrictions %>
   -o milter_macro_daemon_name=ORIGINATING
-<% @smtps_content_filter.each do |content_filter| -%>
-  -o content_filter=<%= content_filter %>
+<% if $smtps_content_filter -%>
+	<% @smtps_content_filter.each do |content_filter| -%>
+		-o content_filter=<%= content_filter %>
+	<% end -%>
 <% end -%>
 <% end -%>
 #628      inet  n       -       n       -       -       qmqpd

--- a/templates/master.cf.erb
+++ b/templates/master.cf.erb
@@ -32,7 +32,7 @@ smtps     inet  n       -       n       -       -       smtpd
   -o smtpd_sasl_auth_enable=<%= @smtps_smtpd_sasl_auth_enable %>
   -o smtpd_client_restrictions=<%= @smtps_smtpd_client_restrictions %>
   -o milter_macro_daemon_name=ORIGINATING
-<% if $smtps_content_filter -%>
+<% if (defined? @smtps_content_filter -%>
 	<% @smtps_content_filter.each do |content_filter| -%>
 		-o content_filter=<%= content_filter %>
 	<% end -%>

--- a/templates/master.cf.erb
+++ b/templates/master.cf.erb
@@ -32,7 +32,7 @@ smtps     inet  n       -       n       -       -       smtpd
   -o smtpd_sasl_auth_enable=<%= @smtps_smtpd_sasl_auth_enable %>
   -o smtpd_client_restrictions=<%= @smtps_smtpd_client_restrictions %>
   -o milter_macro_daemon_name=ORIGINATING
-<% if (defined? @smtps_content_filter -%>
+<% if (defined? @smtps_content_filter) -%>
 	<% @smtps_content_filter.each do |content_filter| -%>
 		-o content_filter=<%= content_filter %>
 	<% end -%>


### PR DESCRIPTION
I found out that using ssl, forces users to also use smtps_content_filter. In my opinion this shouldn't be needed. I added a check in master.cf.erb for checking if smtps_content_filter is defined before looping over the array.