### PR TITLE
fix of a comparison of an integer to a non-integer in centos7

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -159,7 +159,7 @@ class postfix::server (
 ) inherits ::postfix::params {
 
   # Default has el5 files, for el6 a few defaults have changed
-  if ( $::operatingsystem =~ /RedHat|CentOS/ and versioncmp($::operatingsystemrelease, '6') < 0 ) {
+  if ( $::operatingsystem =~ /RedHat|CentOS/ and versioncmp($::operatingsystemmajrelease, '6') < 0 ) {
     $filesuffix = '-el5'
   } else {
     $filesuffix = ''


### PR DESCRIPTION
fix of a comparison of an integer to a non-integer in centos7 (operatingsystemrelease vs operatingsystemmajrelease)