### PR TITLE
added ability to add master_relay_options and master_smtp_options

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -103,6 +103,8 @@ class postfix::server (
   # anyway so no one true answer. 
   $smtps_smtpd_client_restrictions = 'permit_sasl_authenticated',
   $master_services = [],
+  $master_smtp_options = {},
+  $master_relay_options = {},
   # Other files
   $header_checks = [],
   $body_checks = [],

--- a/templates/master.cf-el5.erb
+++ b/templates/master.cf-el5.erb
@@ -39,10 +39,17 @@ verify    unix  -       -       n       -       1       verify
 flush     unix  n       -       n       1000?   0       flush
 proxymap  unix  -       -       n       -       -       proxymap
 smtp      unix  -       -       n       -       -       smtp
+<% @master_smtp_options.each do |option, value| -%>
+  -o <%= option %>=<%= value %>
+<% end -%>
 # When relaying mail as backup MX, disable fallback_relay to avoid MX loops
 relay     unix  -       -       n       -       -       smtp
-	-o smtp_fallback_relay=
-#       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
+<% @master_relay_options.each do |option, value| -%>
+  -o <%= option %>=<%= value %>
+<% end -%>
+<% unless @master_relay_options.has_key?("smtp_fallback_relay") -%>
+  -o smtp_fallback_relay=
+<% end -%>
 showq     unix  n       -       n       -       -       showq
 error     unix  -       -       n       -       -       error
 discard   unix  -       -       n       -       -       discard

--- a/templates/master.cf.erb
+++ b/templates/master.cf.erb
@@ -51,10 +51,17 @@ flush     unix  n       -       n       1000?   0       flush
 proxymap  unix  -       -       n       -       -       proxymap
 proxywrite unix -       -       n       -       1       proxymap
 smtp      unix  -       -       n       -       -       smtp
+<% @master_smtp_options.each do |option, value| -%>
+  -o <%= option %>=<%= value %>
+<% end -%>
 # When relaying mail as backup MX, disable fallback_relay to avoid MX loops
 relay     unix  -       -       n       -       -       smtp
-	-o smtp_fallback_relay=
-#       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
+<% @master_relay_options.each do |option, value| -%>
+  -o <%= option %>=<%= value %>
+<% end -%>
+<% unless @master_relay_options.has_key?("smtp_fallback_relay") -%>
+  -o smtp_fallback_relay=
+<% end -%>
 showq     unix  n       -       n       -       -       showq
 error     unix  -       -       n       -       -       error
 retry     unix  -       -       n       -       -       error


### PR DESCRIPTION
I missed the feature of adding options to the smtp and relay process in master.cf. This patch can set options using the new master_relay_options or master_smtp_options dictionaries.