### PR TITLE
add parameter 'import_environment'

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -39,6 +39,7 @@ class postfix::server (
   $mailbox_size_limit = undef,
   $message_size_limit = false,
   $mail_name = false,
+  $import_environment = false,
   $virtual_alias_domains = false,
   $virtual_alias_maps = false,
   $virtual_mailbox_domains = false,

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -758,6 +758,11 @@ tls_append_default_CA = yes
 <% end -%>
 
 <% end -%>
+
+<% if @import_environment -%>
+import_environment = <%= @import_environment %>
+<% end -%>
+
 <% if @smtpd_sasl_auth -%>
 # Auth against external daemon (usually dovecot or cyrus)
 smtpd_sasl_auth_enable = yes


### PR DESCRIPTION
It is needed, for example, to provide KRB5 keytab filename for postfix.