### PR TITLE
allow inet_interfaces to be an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix spampd options (#46, @chihoko).
 * Add mailbox_size_limit.
 * Allow mynetworks to also be an array.
+* Allow inet_interfaces to also be an array.
 
 #### 2014-05-12 - 0.3.3
 * Add Debian support for spampd (#26, @timogoebel).

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -118,7 +118,12 @@ myorigin = <%= @myorigin %>
 #inet_interfaces = all
 #inet_interfaces = $myhostname
 #inet_interfaces = $myhostname, localhost
+<% if @inet_interfaces and @inet_interfaces.is_a?(String) -%>
 inet_interfaces = <%= @inet_interfaces %>
+<% end -%>
+<% if @inet_interfaces and @inet_interfaces.is_a?(Array) -%>
+inet_interfaces = <%= @inet_interfaces.join(', ') %>
+<% end -%>
 
 # Enable IPv4, and IPv6 if supported
 inet_protocols = <%= @inet_protocols %>


### PR DESCRIPTION
Sometimes it's convenient to restrict inet_interfaces to some of the host's IP addresses.
For example, for postfix gateway accepting mail from trusted local network and having public IP.