### PR TITLE
Add the ability to specify the queue_directory.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class postfix::params {
         '5'     => '2.3.3',
         default => '2.6.6',
       }
+      $queue_directory = '/var/spool/postfix'
       $command_directory = '/usr/sbin'
       $config_directory = '/etc/postfix'
       $daemon_directory = '/usr/libexec/postfix'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -136,6 +136,7 @@ class postfix::server (
   $postgrey_policy_service = undef,
   $clamav                  = false,
   # Parameters
+  $queue_directory        = $::postfix::params::queue_directory,
   $command_directory      = $::postfix::params::command_directory,
   $config_directory       = $::postfix::params::config_directory,
   $daemon_directory       = $::postfix::params::daemon_directory,


### PR DESCRIPTION
My company had the need to change this parameter.  This defaults to /var/spool/postfix if not specified. 