### PR TITLE
Enabling spamassassin on FreeBSD causes catalogue run fail due to broken local.cf path

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,7 @@ class postfix::params {
       $postfix_package_ensure = installed
       $postgrey_package = 'postgrey'
       $spamassassin_package = 'spamassassin'
+      $spamassassin_localcf = '/etc/mail/spamassassin/local.cf'
       $spampd_package = 'spampd'
       $spampd_config = '/etc/sysconfig/spampd'
       $spampd_template = 'postfix/sysconfig-spampd.erb'
@@ -49,6 +50,7 @@ class postfix::params {
       $postfix_package_ensure = installed
       $postgrey_package = 'postgrey'
       $spamassassin_package = 'spamassassin'
+      $spamassassin_localcf = '/etc/mail/spamassassin/local.cf'
       $spampd_package = 'spampd'
       $spampd_config = '/etc/default/spampd'
       $spampd_template = 'postfix/default-spampd.erb'
@@ -75,6 +77,7 @@ class postfix::params {
       $postfix_package_ensure = installed
       $postgrey_package = 'mail/postgrey'
       $spamassassin_package = 'mail/spamassassin'
+      $spamassassin_localcf = '/usr/local/etc/mail/spamassassin/local.cf'
       $spampd_package = 'mail/spampd'
       $spampd_config = '/etc/sysconfig/spampd'
       $spampd_template = 'postfix/sysconfig-spampd.erb'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -152,6 +152,7 @@ class postfix::server (
   $spamassassin_package   = $::postfix::params::spamassassin_package,
   $spampd_package         = $::postfix::params::spampd_package,
   $spampd_config          = $::postfix::params::spampd_config,
+  $spamassassin_localcf   = $::postfix::params::spamassassin_localcf,
   $spampd_template        = $::postfix::params::spampd_template,
   $root_group             = $::postfix::params::root_group,
   $mailq_path             = $::postfix::params::mailq_path,
@@ -211,7 +212,7 @@ class postfix::server (
       notify  => Service['spampd'],
     }
     # Change the spamassassin options
-    file { '/etc/mail/spamassassin/local.cf':
+    file { $spamassassin_localcf:
       require => Package[$spamassassin_package],
       content => template('postfix/spamassassin-local.cf.erb'),
       notify  => Service['spampd'],


### PR DESCRIPTION
Fix: Enabling spamassassin on FreeBSD causes catalogue run to fail due to missing directory / broken path to local.cf. The file resource defining this file is hard coded in server.pp. This is now a variable defined i params.pp and server.pp uses this variable.