### PR TITLE
Compatibility with Postfix 3

### DIFF
--- a/manifests/dbfile.pp
+++ b/manifests/dbfile.pp
@@ -57,4 +57,3 @@ define postfix::dbfile (
   }
 
 }
-

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -47,4 +47,3 @@ define postfix::file (
   }
 
 }
-

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,7 +37,27 @@ class postfix::params {
       $postfix_version = undef
       $command_directory = '/usr/sbin'
       $config_directory = '/etc/postfix'
-      $daemon_directory = '/usr/lib/postfix'
+      case $::lsbdistid {
+        'Ubuntu': {
+          case (versioncmp($::operatingsystemrelease, '16.04') < 0) {
+            true: {
+              $daemon_directory = '/usr/lib/postfix'
+            }
+            default: {
+              $daemon_directory = '/usr/lib/postfix/sbin'
+            }
+          }
+        }
+        'Debian': {
+          $daemon_directory = $::lsbdistcodename ? {
+            /(wheezy|jessie)/ => '/usr/lib/postfix',
+            default           => '/usr/lib/postfix/sbin',
+          }
+        }
+        default: {
+          $daemon_directory = '/usr/lib/postfix'
+        }
+      }
       $data_directory = '/var/lib/postfix'
       $manpage_directory = '/usr/share/man'
       $readme_directory = '/usr/share/doc/postfix'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -109,5 +109,6 @@ class postfix::params {
       fail("Unsupported OS family ${::osfamily}")
     }
   }
-}
 
+  $compatibility_level = 2
+}

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -99,8 +99,8 @@ class postfix::server (
   # reject everything else.
   $submission_smtpd_client_restrictions = 'permit_sasl_authenticated,reject',
   # smtps should allow unauthenticated delivery (for local or relay_domains for
-  # example) so no explicit reject. smtps port 465 is non-standards compliant 
-  # anyway so no one true answer. 
+  # example) so no explicit reject. smtps port 465 is non-standards compliant
+  # anyway so no one true answer.
   $smtps_smtpd_client_restrictions = 'permit_sasl_authenticated',
   $master_services = [],
   # Other files
@@ -156,7 +156,7 @@ class postfix::server (
   $root_group             = $::postfix::params::root_group,
   $mailq_path             = $::postfix::params::mailq_path,
   $newaliases_path        = $::postfix::params::newaliases_path,
-  $sendmail_path          = $::postfix::params::sendmail_path
+  $sendmail_path          = $::postfix::params::sendmail_path,
 ) inherits ::postfix::params {
 
   # Default has el5 files, for el6 a few defaults have changed
@@ -252,4 +252,3 @@ class postfix::server (
   }
 
 }
-

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -157,6 +157,7 @@ class postfix::server (
   $mailq_path             = $::postfix::params::mailq_path,
   $newaliases_path        = $::postfix::params::newaliases_path,
   $sendmail_path          = $::postfix::params::sendmail_path,
+  $compatibility_level    = $::postfix::params::compatibility_level,
 ) inherits ::postfix::params {
 
   # Default has el5 files, for el6 a few defaults have changed

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -10,6 +10,25 @@
 # For best results, change no more than 2-3 parameters at a time,
 # and test if Postfix still works after every change.
 
+# COMPATIBILITY
+#
+# The compatibility_level determines what default settings Postfix
+# will use for main.cf and master.cf settings. These defaults will
+# change over time.
+#
+# To avoid breaking things, Postfix will use backwards-compatible
+# default settings and log where it uses those old backwards-compatible
+# default settings, until the system administrator has determined
+# if any backwards-compatible default settings need to be made
+# permanent in main.cf or master.cf.
+#
+# When this review is complete, update the compatibility_level setting
+# below as recommended in the RELEASE_NOTES file.
+#
+# The default level that should be used with new (not upgrade) installs is 2.
+#
+compatibility_level = <%= @compatibility_level %>
+
 # SOFT BOUNCE
 #
 # The soft_bounce parameter provides a limited safety net for

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -66,7 +66,7 @@ mail_owner = postfix
 #default_privs = nobody
 
 # INTERNET HOST AND DOMAIN NAMES
-# 
+#
 # The myhostname parameter specifies the internet hostname of this
 # mail system. The default is to use the fully-qualified domain name
 # from gethostname(). $myhostname is used as a default value for many
@@ -87,7 +87,7 @@ mydomain = <%= @mydomain %>
 <% end -%>
 
 # SENDING MAIL
-# 
+#
 # The myorigin parameter specifies the domain that locally-posted
 # mail appears to come from. The default is to append $myhostname,
 # which is fine for small sites.  If you run a domain with multiple
@@ -197,7 +197,7 @@ mydestination = <%= @mydestination %>
 #
 # - You define $mydestination domain recipients in files other than
 #   /etc/passwd, /etc/aliases, or the $virtual_alias_maps files.
-#   For example, you define $mydestination domain recipients in    
+#   For example, you define $mydestination domain recipients in
 #   the $virtual_mailbox_maps files.
 #
 # - You redefine the local delivery agent in master.cf.
@@ -217,7 +217,7 @@ mydestination = <%= @mydestination %>
 # The right-hand side of the lookup tables is conveniently ignored.
 # In the left-hand side, specify a bare username, an @domain.tld
 # wild-card, or specify a user@domain.tld address.
-# 
+#
 #local_recipient_maps = unix:passwd.byname $alias_maps
 #local_recipient_maps = proxy:unix:passwd.byname $alias_maps
 #local_recipient_maps =
@@ -255,16 +255,16 @@ unknown_local_recipient_reject_code = <%= @unknown_local_recipient_reject_code %
 # clients in the same IP subnetworks as the local machine.
 # On Linux, this does works correctly only with interfaces specified
 # with the "ifconfig" command.
-# 
+#
 # Specify "mynetworks_style = class" when Postfix should "trust" SMTP
 # clients in the same IP class A/B/C networks as the local machine.
 # Don't do this with a dialup site - it would cause Postfix to "trust"
 # your entire provider's network.  Instead, specify an explicit
 # mynetworks list by hand, as described below.
-#  
+#
 # Specify "mynetworks_style = host" when Postfix should "trust"
 # only the local machine.
-# 
+#
 #mynetworks_style = class
 #mynetworks_style = subnet
 #mynetworks_style = host
@@ -302,7 +302,7 @@ mynetworks = <%= @mynetworks.join(', ') %>
 # - from "untrusted" clients to destinations that match $relay_domains or
 #   subdomains thereof, except addresses with sender-specified routing.
 # The default relay_domains value is $mydestination.
-# 
+#
 # In addition to the above, the Postfix SMTP server by default accepts mail
 # that Postfix is final destination for:
 # - destinations that match $inet_interfaces or $proxy_interfaces,
@@ -310,7 +310,7 @@ mynetworks = <%= @mynetworks.join(', ') %>
 # - destinations that match $virtual_alias_domains,
 # - destinations that match $virtual_mailbox_domains.
 # These destinations do not need to be listed in $relay_domains.
-# 
+#
 # Specify a list of hosts or domains, /file/name patterns or type:name
 # lookup tables, separated by commas and/or whitespace.  Continue
 # long lines by starting the next line with whitespace. A file name
@@ -361,7 +361,7 @@ relayhost = <%= @relayhost %>
 # The right-hand side of the lookup tables is conveniently ignored.
 # In the left-hand side, specify an @domain.tld wild-card, or specify
 # a user@domain.tld address.
-# 
+#
 #relay_recipient_maps = hash:/etc/postfix/relay_recipients
 <% if @relay_recipient_maps -%>
 relay_recipient_maps = <%= @relay_recipient_maps %>
@@ -373,15 +373,15 @@ relay_recipient_maps = <%= @relay_recipient_maps %>
 # flow control. This feature is turned on by default, although it
 # still needs further development (it's disabled on SCO UNIX due
 # to an SCO bug).
-# 
+#
 # A Postfix process will pause for $in_flow_delay seconds before
 # accepting a new message, when the message arrival rate exceeds the
 # message delivery rate. With the default 100 SMTP server process
 # limit, this limits the mail inflow to 100 messages a second more
 # than the number of messages delivered per second.
-# 
+#
 # Specify 0 to disable the feature. Valid delays are 0..10.
-# 
+#
 #in_flow_delay = 1s
 in_flow_delay = <%= @in_flow_delay %>
 
@@ -424,7 +424,7 @@ relocated_maps = <%= @relocated_maps %>
 # On systems with NIS, the default is to search the local alias
 # database, then the NIS alias database. See aliases(5) for syntax
 # details.
-# 
+#
 # If you change the alias database, run "postalias /etc/aliases" (or
 # wherever your system stores the mail alias file), or simply run
 # "newaliases" to build the necessary DBM or DB file.
@@ -521,7 +521,7 @@ mailbox_command = <%= @mailbox_command %>
 #
 # NOTE: if you use this feature for accounts not in the UNIX password
 # file, then you must update the "local_recipient_maps" setting in
-# the main.cf file, otherwise the SMTP server will reject mail for    
+# the main.cf file, otherwise the SMTP server will reject mail for
 # non-UNIX accounts with "User unknown in local recipient table".
 #
 #mailbox_transport = lmtp:unix:/var/lib/imap/socket/lmtp
@@ -544,7 +544,7 @@ mailbox_command = <%= @mailbox_command %>
 # can be used to take advantage of the single instance message store
 # capability of Cyrus. The concurrency limit can be used to control
 # how many simultaneous LMTP sessions will be permitted to the Cyrus
-# message store. 
+# message store.
 #
 # To use the old cyrus deliver program you have to set:
 #mailbox_transport = cyrus
@@ -560,7 +560,7 @@ mailbox_command = <%= @mailbox_command %>
 #
 # NOTE: if you use this feature for accounts not in the UNIX password
 # file, then you must update the "local_recipient_maps" setting in
-# the main.cf file, otherwise the SMTP server will reject mail for    
+# the main.cf file, otherwise the SMTP server will reject mail for
 # non-UNIX accounts with "User unknown in local recipient table".
 #
 #fallback_transport = lmtp:unix:/var/lib/imap/socket/lmtp
@@ -582,7 +582,7 @@ mailbox_command = <%= @mailbox_command %>
 #
 # NOTE: if you use this feature for accounts not in the UNIX password
 # file, then you must specify "local_recipient_maps =" (i.e. empty) in
-# the main.cf file, otherwise the SMTP server will reject mail for    
+# the main.cf file, otherwise the SMTP server will reject mail for
 # non-UNIX accounts with "User unknown in local recipient table".
 #
 #luser_relay = $user@other.host
@@ -590,7 +590,7 @@ mailbox_command = <%= @mailbox_command %>
 #luser_relay = admin+$local
 
 # JUNK MAIL CONTROLS
-# 
+#
 # The controls listed here are only a very small subset. The file
 # SMTPD_ACCESS_README provides an overview.
 
@@ -612,11 +612,11 @@ header_checks = regexp:<%= @config_directory %>/header_checks
 # deferred mail, so that mail can be flushed quickly with the SMTP
 # "ETRN domain.tld" command, or by executing "sendmail -qRdomain.tld".
 # See the ETRN_README document for a detailed description.
-# 
+#
 # The fast_flush_domains parameter controls what destinations are
 # eligible for this service. By default, they are all domains that
 # this server is willing to relay mail to.
-# 
+#
 #fast_flush_domains = $relay_domains
 
 # SHOW SOFTWARE VERSION OR NOT
@@ -641,7 +641,7 @@ smtpd_banner = <%= @smtpd_banner %>
 # too many are run at the same time. With SMTP deliveries, 10
 # simultaneous connections to the same domain could be sufficient to
 # raise eyebrows.
-# 
+#
 # Each message delivery transport has its XXX_destination_concurrency_limit
 # parameter.  The default is $default_destination_concurrency_limit for
 # most delivery transports. For the local delivery agent the default is 2.
@@ -674,8 +674,8 @@ debug_peer_level = 2
 # set up your XAUTHORITY environment variable before starting Postfix.
 #
 debugger_command =
-	 PATH=/bin:/usr/bin:/usr/local/bin:/usr/X11R6/bin
-	 ddd $daemon_directory/$process_name $process_id & sleep 5
+   PATH=/bin:/usr/bin:/usr/local/bin:/usr/X11R6/bin
+   ddd $daemon_directory/$process_name $process_id & sleep 5
 
 # If you can't use X, use this to capture the call stack when a
 # daemon crashes. The result is in a file in the configuration
@@ -699,10 +699,10 @@ debugger_command =
 # INSTALL-TIME CONFIGURATION INFORMATION
 #
 # The following parameters are used when installing a new Postfix version.
-# 
+#
 # sendmail_path: The full pathname of the Postfix sendmail command.
 # This is the Sendmail-compatible mail posting interface.
-# 
+#
 sendmail_path = <%= @sendmail_path %>
 
 # newaliases_path: The full pathname of the Postfix newaliases command.
@@ -712,7 +712,7 @@ newaliases_path = <%= @newaliases_path %>
 
 # mailq_path: The full pathname of the Postfix mailq command.  This
 # is the Sendmail-compatible mail queue listing command.
-# 
+#
 mailq_path = <%= @mailq_path %>
 
 # setgid_group: The group for mail submission and queue management


### PR DESCRIPTION
Postfix 3 introduces a `compatibility_level` setting and changes the default value of `daemon_directory`.

Also includes linting of primarily trailing spaces.