### PR TITLE
Add smtpd_tls_CApath support

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -61,6 +61,7 @@ class postfix::server (
   $smtpd_tls_key_file = undef,
   $smtpd_tls_cert_file = undef,
   $smtpd_tls_CAfile = undef,
+  $smtpd_tls_CApath = undef,
   $smtpd_sasl_auth = false,
   $smtpd_sasl_type = 'dovecot',
   $smtpd_sasl_path = 'private/auth',

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -754,6 +754,14 @@ smtpd_tls_ask_ccert = yes
 tls_append_default_CA = yes
 <% end -%>
 
+<% if @smtpd_tls_CAfile -%>
+smtpd_tls_CAfile = <%= @smtpd_tls_CAfile %>
+<% end -%>
+
+<% if @smtpd_tls_CApath -%>
+smtpd_tls_CApath = <%= @smtpd_tls_CApath %>
+<% end -%>
+
 <% end -%>
 <% if @smtpd_sasl_auth -%>
 # Auth against external daemon (usually dovecot or cyrus)


### PR DESCRIPTION
Add support for smtpd_tls_CApath to be consistent with smtp_tls_CApath.