### PR TITLE
Add support for disabling the SMTP listener

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -58,6 +58,7 @@ class postfix::server (
   $smtpd_data_restrictions = [],
   $smtpd_end_of_data_restrictions = [],
   $smtpd_delay_reject = false,
+  $smtp = true,
   $ssl = false,
   $smtpd_tls_key_file = undef,
   $smtpd_tls_cert_file = undef,
@@ -99,8 +100,8 @@ class postfix::server (
   # reject everything else.
   $submission_smtpd_client_restrictions = 'permit_sasl_authenticated,reject',
   # smtps should allow unauthenticated delivery (for local or relay_domains for
-  # example) so no explicit reject. smtps port 465 is non-standards compliant 
-  # anyway so no one true answer. 
+  # example) so no explicit reject. smtps port 465 is non-standards compliant
+  # anyway so no one true answer.
   $smtps_smtpd_client_restrictions = 'permit_sasl_authenticated',
   $master_services = [],
   # Other files

--- a/templates/master.cf.erb
+++ b/templates/master.cf.erb
@@ -8,6 +8,7 @@
 # service type  private unpriv  chroot  wakeup  maxproc command + args
 #               (yes)   (yes)   (yes)   (never) (100)
 # ==========================================================================
+<% if @smtp -%>
 <% unless @postscreen -%>
 smtp      inet  n       -       n       -       -       smtpd
 <% else -%>
@@ -18,6 +19,7 @@ smtpd     pass  -       -       n       -       -       smtpd
 <% end -%>
 <% @smtp_content_filter.each do |content_filter| -%>
   -o content_filter=<%= content_filter %>
+<% end -%>
 <% end -%>
 <% if @submission -%>
 submission inet n       -       n       -       -       smtpd


### PR DESCRIPTION
Adds a `$postfix::server::smtp` parameter (defaults to `true`). This paramater can be used to disable the SMTP listener.
