### PR TITLE
add param to change the type of header_checks

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -105,6 +105,7 @@ class postfix::server (
   $master_services = [],
   # Other files
   $header_checks = [],
+  $header_checks_type = 'regexp',
   $body_checks = [],
   # Postscreen - available in Postfix 2.8 and later
   $postscreen                  = false,

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -604,7 +604,7 @@ mailbox_command = <%= @mailbox_command %>
 #
 # For details, see "man header_checks".
 #
-header_checks = regexp:<%= @config_directory %>/header_checks
+header_checks = <%= @header_checks_type %>:<%= @config_directory %>/header_checks
 
 # FAST ETRN SERVICE
 #


### PR DESCRIPTION
Allows you to specify a different type such as `pcre`