### PR TITLE
Patch params for Ubuntu 16.04+.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,7 +37,13 @@ class postfix::params {
       $postfix_version = undef
       $command_directory = '/usr/sbin'
       $config_directory = '/etc/postfix'
-      $daemon_directory = '/usr/lib/postfix'
+      $daemon_directory = $::operatingsystemmajrelease ? {
+       '16.04' => '/usr/lib/postfix/sbin',
+       '16.10' => '/usr/lib/postfix/sbin',
+       '17.04' => '/usr/lib/postfix/sbin',
+       '17.10' => '/usr/lib/postfix/sbin',
+       default => '/usr/lib/postfix',
+      }
       $data_directory = '/var/lib/postfix'
       $manpage_directory = '/usr/share/man'
       $readme_directory = '/usr/share/doc/postfix'


### PR DESCRIPTION
Here is a patch to fix a service warning on Ubuntu 16.04+.  There might be other things that need fixing too, but this fixes a visible issue in the default install.

Postfix decided to disallow shlib_directory = daemon_directory in 3.0+.  Ubuntu added an 'sbin' subdir to house the daemon_directory going forward.  I added this new location to daemon_directory in params.pp.

A better way might be to set the old default for all existing old Ubuntu versions & change the 'default' case to the new default.  But this way works best for my existing environment.

I also attach a patch, in case people want to patch current release to work on
[thias-postfix_patch.txt](https://github.com/thias/puppet-postfix/files/883620/thias-postfix_patch.txt)
 xenial.