### PR TITLE
use an onlyif+test check

### DIFF
--- a/manifests/dbfile.pp
+++ b/manifests/dbfile.pp
@@ -47,11 +47,11 @@ define postfix::dbfile (
 
   } else {
 
-    exec { "${postmap} ${title}":
+    exec { "${postmap} ${postfixdir}/${title}":
       cwd         => $postfixdir,
       subscribe   => File["${postfixdir}/${title}"],
       refreshonly => true,
-      # No need to notify the service, since it detects changed files
+      onlyif      => "/usr/bin/test ${postfixdir}/${title} -nt ${postfixdir}/${title}.db"
     }
 
   }


### PR DESCRIPTION
If the human-readable text file is newer than the database file, (re)create

This solves the issue outlined in https://github.com/thias/puppet-postfix/issues/113 & https://github.com/thias/puppet-postfix/pull/114 but in a different way; the `creates` attribute is not useful here.

https://docs.puppet.com/puppet/latest/type.html#exec-attribute-creates

`A file to look for before running the command. The command will only run if the file doesn’t exist.`

If the file _does_ exist, but the originating resource is updated, the .db file is _not recreated_.

Here's a quick example:

```
# cat creates.pp
node default {

  file { "/tmp/file1":
    ensure  => present,
    content => "test\n",
  }

  exec { "/tmp/file2":
    command     => "/bin/cat /tmp/file1 > /tmp/file2",
    subscribe   => File["/tmp/file1"],
    creates     => "/tmp/file2",
  }

}
```

```
#puppet apply creates.pp
Notice: Compiled catalog for SERVER in environment production in 0.38 seconds
Notice: /Stage[main]/Main/Node[default]/File[/tmp/file1]/ensure: created
Notice: /Stage[main]/Main/Node[default]/Exec[/tmp/file2]/returns: executed successfully
Notice: /Stage[main]/Main/Node[default]/Exec[/tmp/file2]: Triggered 'refresh' from 1 events
Notice: Finished catalog run in 0.17 seconds
# cat /tmp/file1
test
cat /tmp/file2
test
```

Now, change `file1`:

```
# cat creates.pp
node default {

  file { "/tmp/file1":
    ensure  => present,
    content => "quux\n",
  }

  exec { "/tmp/file2":
    command     => "/bin/cat /tmp/file1 > /tmp/file2",
    subscribe   => File["/tmp/file1"],
    creates     => "/tmp/file2",
  }

}
```

```
# puppet apply creates.pp
Notice: Compiled catalog for SERVER in environment production in 0.38 seconds
Notice: /Stage[main]/Main/Node[default]/File[/tmp/file1]/content: content changed '{md5}d8e8fca2dc0f896fd7cb4cb0031ba249' to '{md5}d3b07a382ec010c01889250fce66fb13'
Notice: /Stage[main]/Main/Node[default]/Exec[/tmp/file2]: Triggered 'refresh' from 1 events
Notice: Finished catalog run in 0.12 seconds
# cat /tmp/file1
quux
# cat /tmp/file2
test
```

The puppet output isn't helpful here - `file2` is "triggered" but because the file already exists it actually doesn't update.

The fix:

```
cat creates.pp
node default {

  file { "/tmp/file1":
    ensure  => present,
    content => "quux\n",
  }

  exec { "/tmp/file2":
    command     => "/bin/cat /tmp/file1 > /tmp/file2",
    subscribe   => File["/tmp/file1"],
    onlyif      => "/usr/bin/test /tmp/file1 -nt /tmp/file2",
  }

}
```

```
puppet apply creates.pp
Notice: Compiled catalog for SERVER in environment production in 0.36 seconds
Notice: /Stage[main]/Main/Node[default]/Exec[/tmp/file2]/returns: executed successfully
Notice: Finished catalog run in 0.23 seconds
# cat /tmp/file1
quux
# cat /tmp/file2
quux
```