### PR TITLE
 add check_policy_service only when postgrey set to true

### DIFF
--- a/templates/main.cf-el5.erb
+++ b/templates/main.cf-el5.erb
@@ -886,10 +886,12 @@ smtpd_recipient_restrictions =
 <% @smtpd_recipient_restrictions.each do |line| -%>
   <%= line %>,
 <% end -%>
+<% if @postgrey -%>
 <% if @postgrey_policy_service -%>
   check_policy_service <%= @postgrey_policy_service %>,
 <% else -%>
   check_policy_service unix:postgrey/socket,
+<% end -%>
 <% end -%>
 
 <% end -%>

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -908,10 +908,12 @@ smtpd_recipient_restrictions =
 <% @smtpd_recipient_restrictions.each do |line| -%>
   <%= line %>,
 <% end -%>
+<% if @postgrey -%>
 <% if @postgrey_policy_service -%>
   check_policy_service <%= @postgrey_policy_service %>,
 <% else -%>
   check_policy_service unix:postgrey/socket,
+<% end -%>
 <% end -%>
 
 <% end -%>


### PR DESCRIPTION
Currently check_policy_service unix:postgrey/socket is always added to smtpd_recipient_restrictions independently of what $postgrey is set (provided smtpd_recipient_restrictions is not empty). Added check into erb templates.