### PR TITLE
add support for debian 9 stretch major release

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,7 +37,10 @@ class postfix::params {
       $postfix_version = undef
       $command_directory = '/usr/sbin'
       $config_directory = '/etc/postfix'
-      $daemon_directory = '/usr/lib/postfix'
+      $daemon_directory = $::operatingsystemmajrelease ? {
+        '9'     => '/usr/lib/postfix/sbin',
+        default => '/usr/lib/postfix',
+      }
       $data_directory = '/var/lib/postfix'
       $manpage_directory = '/usr/share/man'
       $readme_directory = '/usr/share/doc/postfix'


### PR DESCRIPTION
new version of postfix 3+ moved daemon_folder to /usr/lib/postfix/sbin


