### PR TITLE
Enable the use of different table types for header_checks and body_checks

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -104,6 +104,7 @@ class postfix::server (
   $smtps_smtpd_client_restrictions = 'permit_sasl_authenticated',
   $master_services = [],
   # Other files
+  $header_checks_type = 'regexp',
   $header_checks = [],
   $body_checks = [],
   # Postscreen - available in Postfix 2.8 and later

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -106,6 +106,7 @@ class postfix::server (
   # Other files
   $header_checks_type = 'regexp',
   $header_checks = [],
+  $body_checks_type = 'regexp',
   $body_checks = [],
   # Postscreen - available in Postfix 2.8 and later
   $postscreen                  = false,

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -604,7 +604,7 @@ mailbox_command = <%= @mailbox_command %>
 #
 # For details, see "man header_checks".
 #
-header_checks = regexp:<%= @config_directory %>/header_checks
+header_checks = <%= @header_checks_type %>:<%= @config_directory %>/header_checks
 
 # FAST ETRN SERVICE
 #

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -929,7 +929,7 @@ smtpd_end_of_data_restrictions =
 <% end -%>
 
 <% end -%>
-body_checks = regexp:<%= @config_directory %>/body_checks
+body_checks = <%= @body_checks_type %>:<%= @config_directory %>/body_checks
 
 <% if @canonical_maps -%>
 canonical_maps = <%= @canonical_maps %>


### PR DESCRIPTION
Postfix can use many different table types; see "Table lookup mechanisms" under (Postfix Manual Pages)[http://www.postfix.org/postfix-manuals.html]. This patch easily enables a person to choose the type which works best for them. The default stays as `regexp`, but the user can input what ever they need and if they input a bad value, then it's on them to fix it.

Ta,

Phil